### PR TITLE
Join datasets generation

### DIFF
--- a/h2o-data-rust/README.md
+++ b/h2o-data-rust/README.md
@@ -1,0 +1,14 @@
+# H2O datasets generator
+
+```{bash}
+cargo build --release
+target/release/h2o_data_generator --help
+```
+
+## Output
+
+1. Group By dataset
+2. Join dataset (LHS)
+3. Join dataset (LHS) with NAs
+4. Join dataset (RHS) medium
+5. Join dataset (RHS) small

--- a/h2o-data-rust/src/generators.rs
+++ b/h2o-data-rust/src/generators.rs
@@ -1,0 +1,168 @@
+use rand::distributions::Uniform;
+use rand::prelude::*;
+use rand_chacha::ChaCha8Rng;
+
+pub trait RowGenerator {
+    fn new(n: u64, k: u64, nas: u8, seed: u64) -> Self
+    where
+        Self: Sized;
+    fn get_csv_header(&self) -> String;
+    fn get_csv_row(&mut self) -> String;
+}
+
+pub struct GroupByGenerator {
+    nas: u8,
+    distr_k: Uniform<u64>,
+    distr_nk: Uniform<u64>,
+    distr_5: Uniform<u8>,
+    distr_15: Uniform<u8>,
+    distr_float: Uniform<f64>,
+    distr_nas: Uniform<u8>,
+    rng: ChaCha8Rng,
+}
+
+pub struct JoinGeneratorBig {
+    nas: u8,
+    keys_1: Vec<u64>,
+    keys_2: Vec<u64>,
+    keys_3: Vec<u64>,
+    distr_float: Uniform<f64>,
+    rng: ChaCha8Rng,
+}
+
+pub struct JoinGeneratorMedium {
+    nas: u8,
+    distr_k1: Uniform<u64>,
+    distr_k2: Uniform<u64>,
+    distr_float: Uniform<f64>,
+    rng: ChaCha8Rng,
+}
+
+pub struct JoinGeneratorSmall {
+    nas: u8,
+    distr_k1: Uniform<u64>,
+    distr_float: Uniform<f64>,
+    rng: ChaCha8Rng,
+}
+
+impl RowGenerator for GroupByGenerator {
+    fn new(n: u64, k: u64, nas: u8, seed: u64) -> Self {
+        GroupByGenerator {
+            nas,
+            distr_k: Uniform::<u64>::try_from(1..=k).unwrap(),
+            distr_nk: Uniform::<u64>::try_from(1..=(n / k)).unwrap(),
+            distr_5: Uniform::<u8>::try_from(1..=5).unwrap(),
+            distr_15: Uniform::<u8>::try_from(1..=15).unwrap(),
+            distr_float: Uniform::<f64>::try_from(0.0..=100.0).unwrap(),
+            distr_nas: Uniform::<u8>::try_from(0..=100).unwrap(),
+            rng: ChaCha8Rng::seed_from_u64(seed),
+        }
+    }
+    fn get_csv_header(&self) -> String {
+        "id1,id2,id3,id4,id5,id6,v1,v2,v3\n".to_string()
+    }
+
+    fn get_csv_row(&mut self) -> String {
+        format!(
+            "{},{},{},{},{},{},{:.5},{:.5},{:.5}\n",
+            if self.distr_nas.sample(&mut self.rng) >= self.nas {
+                format!("id{:03}", self.distr_k.sample(&mut self.rng))
+            } else {
+                "".to_string()
+            },
+            if self.distr_nas.sample(&mut self.rng) >= self.nas {
+                format!("id{:03}", self.distr_k.sample(&mut self.rng))
+            } else {
+                "".to_string()
+            },
+            if self.distr_nas.sample(&mut self.rng) >= self.nas {
+                format!("id{:010}", self.distr_nk.sample(&mut self.rng))
+            } else {
+                "".to_string()
+            },
+            if self.distr_nas.sample(&mut self.rng) >= self.nas {
+                format!("{}", self.distr_k.sample(&mut self.rng))
+            } else {
+                "".to_string()
+            },
+            if self.distr_nas.sample(&mut self.rng) >= self.nas {
+                format!("{}", self.distr_k.sample(&mut self.rng))
+            } else {
+                "".to_string()
+            },
+            if self.distr_nas.sample(&mut self.rng) >= self.nas {
+                format!("{}", self.distr_nk.sample(&mut self.rng))
+            } else {
+                "".to_string()
+            },
+            self.distr_5.sample(&mut self.rng),
+            self.distr_15.sample(&mut self.rng),
+            self.distr_float.sample(&mut self.rng),
+        )
+    }
+}
+
+impl RowGenerator for JoinGeneratorBig {
+    fn new(n: u64, k: u64, nas: u8, seed: u64) -> Self {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let mut k1: Vec<u64> = (1..=(n * 11 / 10 / 1_000_000)).collect(); // original line: key1 = split_xlr(N/1e6)
+        k1.shuffle(&mut rng);
+
+        let mut k2: Vec<u64> = (1..=(n * 11 / 10 / 1_000)).collect(); // original line: key2 = split_xlr(N/1e3)
+        k2.shuffle(&mut rng);
+
+        let mut k3: Vec<u64> = (1..=(n * 11 / 10)).collect(); // original line: key3 = split_xlr(N)
+        k3.shuffle(&mut rng);
+
+        // orginial line (43:44)
+        // x = key[seq.int(1, n*0.9)],
+        // l = key[seq.int(n*0.9+1, n)],
+        // Sampling both (x, l) is equal to sampling from 1..n
+        // where n = n / 1e6
+        k1 = k1
+            .get(1..=(n as usize / 1_000_000))
+            .expect("internal indexing error with k1")
+            .to_vec();
+
+        // same logic here
+        // see https://github.com/h2oai/db-benchmark/blob/master/_data/join-datagen.R#L40
+        // for details
+        k2 = k2
+            .get(1..=(n as usize / 1_000))
+            .expect("internal indexing error with k2")
+            .to_vec();
+        k3 = k3
+            .get(1..=(n as usize))
+            .expect("internal indexing error with k3")
+            .to_vec();
+
+        JoinGeneratorBig {
+            nas,
+            keys_1: k1,
+            keys_2: k2,
+            keys_3: k3,
+            distr_float: Uniform::try_from(0.0..=100.0).unwrap(),
+            rng,
+        }
+    }
+
+    fn get_csv_header(&self) -> String {
+        "id1,id2,id3,id4,id5,id6,v2\n".to_string()
+    }
+
+    fn get_csv_row(&mut self) -> String {
+        let k1 = self.keys_1.choose(&mut self.rng).unwrap();
+        let k2 = self.keys_2.choose(&mut self.rng).unwrap();
+        let k3 = self.keys_3.choose(&mut self.rng).unwrap();
+        format!(
+            "{},{},{},id{},id{},id{},{:.5}\n",
+            k1,
+            k2,
+            k3,
+            k1,
+            k2,
+            k3,
+            self.distr_float.sample(&mut self.rng),
+        )
+    }
+}

--- a/h2o-data-rust/src/generators.rs
+++ b/h2o-data-rust/src/generators.rs
@@ -27,20 +27,19 @@ pub struct JoinGeneratorBig {
     keys_2: Vec<u64>,
     keys_3: Vec<u64>,
     distr_float: Uniform<f64>,
+    distr_nas: Uniform<u8>,
     rng: ChaCha8Rng,
 }
 
 pub struct JoinGeneratorMedium {
-    nas: u8,
-    distr_k1: Uniform<u64>,
-    distr_k2: Uniform<u64>,
+    keys_1: Vec<u64>,
+    keys_2: Vec<u64>,
     distr_float: Uniform<f64>,
     rng: ChaCha8Rng,
 }
 
 pub struct JoinGeneratorSmall {
-    nas: u8,
-    distr_k1: Uniform<u64>,
+    keys_1: Vec<u64>,
     distr_float: Uniform<f64>,
     rng: ChaCha8Rng,
 }
@@ -103,6 +102,7 @@ impl RowGenerator for GroupByGenerator {
 }
 
 impl RowGenerator for JoinGeneratorBig {
+    #[allow(unused_variables)]
     fn new(n: u64, k: u64, nas: u8, seed: u64) -> Self {
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
         let mut k1: Vec<u64> = (1..=(n * 11 / 10 / 1_000_000)).collect(); // original line: key1 = split_xlr(N/1e6)
@@ -120,7 +120,7 @@ impl RowGenerator for JoinGeneratorBig {
         // Sampling both (x, l) is equal to sampling from 1..n
         // where n = n / 1e6
         k1 = k1
-            .get(1..=(n as usize / 1_000_000))
+            .get(0..(n as usize / 1_000_000))
             .expect("internal indexing error with k1")
             .to_vec();
 
@@ -128,11 +128,11 @@ impl RowGenerator for JoinGeneratorBig {
         // see https://github.com/h2oai/db-benchmark/blob/master/_data/join-datagen.R#L40
         // for details
         k2 = k2
-            .get(1..=(n as usize / 1_000))
+            .get(0..(n as usize / 1_000))
             .expect("internal indexing error with k2")
             .to_vec();
         k3 = k3
-            .get(1..=(n as usize))
+            .get(0..(n as usize))
             .expect("internal indexing error with k3")
             .to_vec();
 
@@ -142,6 +142,7 @@ impl RowGenerator for JoinGeneratorBig {
             keys_2: k2,
             keys_3: k3,
             distr_float: Uniform::try_from(0.0..=100.0).unwrap(),
+            distr_nas: Uniform::<u8>::try_from(0..=100).unwrap(),
             rng,
         }
     }
@@ -156,12 +157,136 @@ impl RowGenerator for JoinGeneratorBig {
         let k3 = self.keys_3.choose(&mut self.rng).unwrap();
         format!(
             "{},{},{},id{},id{},id{},{:.5}\n",
+            if self.distr_nas.sample(&mut self.rng) >= self.nas {
+                format!("{}", k1)
+            } else {
+                "".to_string()
+            },
+            if self.distr_nas.sample(&mut self.rng) >= self.nas {
+                format!("{}", k2)
+            } else {
+                "".to_string()
+            },
+            if self.distr_nas.sample(&mut self.rng) >= self.nas {
+                format!("{}", k3)
+            } else {
+                "".to_string()
+            },
             k1,
             k2,
             k3,
+            if self.distr_nas.sample(&mut self.rng) >= self.nas {
+                format!("{}", self.distr_float.sample(&mut self.rng))
+            } else {
+                "".to_string()
+            },
+        )
+    }
+}
+
+impl RowGenerator for JoinGeneratorSmall {
+    #[allow(unused_variables)]
+    fn new(n: u64, k: u64, nas: u8, seed: u64) -> Self {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let mut k1: Vec<u64> = (1..=(n * 11 / 10 / 1_000_000)).collect(); // original line: key1 = split_xlr(N/1e6)
+        k1.shuffle(&mut rng);
+
+        // orginial line (43:44)
+        // x = key[seq.int(1, n*0.9)],
+        // l = key[seq.int(n*0.9+1, n)],
+        // r = key[seq.int(n+1, n*1.1)]
+        // we need (x, r) here
+        let mut kx = k1
+            .get(0..(n as usize * 9 / 10 / 1_000_000))
+            .expect("internal indexing error with k1")
+            .to_vec();
+        let mut kr = k1
+            .get((n as usize / 1_000_000)..(n as usize * 11 / 10 / 1_000_000))
+            .expect("internal indexing error with k1")
+            .to_vec();
+
+        kx.append(&mut kr);
+
+        JoinGeneratorSmall {
+            keys_1: kx,
+            distr_float: Uniform::try_from(1.0..=100.0).unwrap(),
+            rng,
+        }
+    }
+
+    fn get_csv_header(&self) -> String {
+        "id1,id4,v2\n".to_string()
+    }
+
+    fn get_csv_row(&mut self) -> String {
+        let k1 = self.keys_1.choose(&mut self.rng).unwrap();
+        format!(
+            "{},id{},{:.5}\n",
+            k1,
+            k1,
+            self.distr_float.sample(&mut self.rng),
+        )
+    }
+}
+
+impl RowGenerator for JoinGeneratorMedium {
+    #[allow(unused_variables)]
+    fn new(n: u64, k: u64, nas: u8, seed: u64) -> Self {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let mut k1: Vec<u64> = (1..=(n * 11 / 10 / 1_000_000)).collect(); // original line: key1 = split_xlr(N/1e6)
+        k1.shuffle(&mut rng);
+
+        let mut k2: Vec<u64> = (1..=(n * 11 / 10 / 1_000)).collect(); // original line: key2 = split_xlr(N/1e3)
+        k2.shuffle(&mut rng);
+
+        // orginial line (43:44)
+        // x = key[seq.int(1, n*0.9)],
+        // l = key[seq.int(n*0.9+1, n)],
+        // Sampling both (x, l) is equal to sampling from 1..n
+        // where n = n / 1e6
+        let mut k1x = k1
+            .get(0..(n as usize * 9 / 10 / 1_000_000))
+            .expect("internal indexing error with k1")
+            .to_vec();
+        let mut k1r = k1
+            .get((n as usize / 1_000_000)..(n as usize * 11 / 10 / 1_000_000))
+            .expect("internal indexing error with k1")
+            .to_vec();
+
+        k1x.append(&mut k1r);
+
+        let mut k2x = k2
+            .get(0..(n as usize * 9 / 10 / 1_000_000))
+            .expect("internal indexing error with k1")
+            .to_vec();
+        let mut k2r = k2
+            .get((n as usize / 1_000_000)..(n as usize * 11 / 10 / 1_000_000))
+            .expect("internal indexing error with k1")
+            .to_vec();
+
+        k2x.append(&mut k2r);
+
+        JoinGeneratorMedium {
+            keys_1: k1x,
+            keys_2: k2x,
+            distr_float: Uniform::try_from(1.0..=100.0).unwrap(),
+            rng,
+        }
+    }
+
+    fn get_csv_header(&self) -> String {
+        "id1,id2,id4,id5,v2\n".to_string()
+    }
+
+    fn get_csv_row(&mut self) -> String {
+        let k1 = self.keys_1.choose(&mut self.rng).unwrap();
+        let k2 = self.keys_2.choose(&mut self.rng).unwrap();
+        format!(
+            "{},{},id{},id{},{:.5}\n",
             k1,
             k2,
-            k3,
+            k1,
+            k2,
             self.distr_float.sample(&mut self.rng),
         )
     }

--- a/h2o-data-rust/src/main.rs
+++ b/h2o-data-rust/src/main.rs
@@ -5,11 +5,17 @@ use std::thread;
 use std::{fs, path::PathBuf};
 
 use clap::Parser;
-use generators::JoinGeneratorBig;
+use generators::JoinGeneratorMedium;
 use kdam::{tqdm, Bar, BarExt};
 
-use crate::generators::{GroupByGenerator, RowGenerator};
+use crate::generators::{GroupByGenerator, RowGenerator, JoinGeneratorBig, JoinGeneratorSmall};
 
+/// H2O benchmark data generator. See https://github.com/h2oai/db-benchmark/tree/master/_data for details.
+/// Generate four datasets. G1_1e7_1e2_0.csv - groupby dataset (1e7 points, 1e2 keys);
+/// J1_1e7_1e7_NA.csv - big join dataset (1e7 points);
+/// J1_1e7_1e7_5e0.csv - big join dataset (1e7 points, 5% NA in join keys);
+/// J1_1e7_1e4.csv - medium join dataset (1e4 points, 1e7 base);
+/// J1_1e7_1e1.csv - small join dataset (1e1 points, 1e7 base);
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct CliArgs {
@@ -31,6 +37,9 @@ struct CliArgs {
 }
 
 fn pretty_sci(num: u64) -> String {
+    if num == 0 {
+        return "NA".to_string()
+    };
     let mut digits: Vec<u8> = Vec::new();
     let mut x = num;
     while x > 0 {
@@ -89,9 +98,27 @@ fn main() {
             "J1_{}_{}_{}.csv",
             pretty_sci(args.n),
             pretty_sci(args.n),
-            pretty_sci(args.nas.into()),
+            "NA",
         );
         let mut pb = tqdm!(total = args.n as usize, position = 1);
+        pb.set_postfix(format!("{}", output_name));
+        let _ = pb.refresh();
+        generate_csv(
+            &mut JoinGeneratorBig::new(args.n, args.k, 0, args.seed),
+            &output_name,
+            &mut pb,
+            args.n,
+        );
+    });
+
+    let _joinbig_na_gen = thread::spawn(move || {
+        let output_name = format!(
+            "J1_{}_{}_{}.csv",
+            pretty_sci(args.n),
+            pretty_sci(args.n),
+            args.nas,
+        );
+        let mut pb = tqdm!(total = args.n as usize, position = 2);
         pb.set_postfix(format!("{}", output_name));
         let _ = pb.refresh();
         generate_csv(
@@ -102,6 +129,47 @@ fn main() {
         );
     });
 
+    let _joinsmall_gen = thread::spawn(move || {
+        let output_name = format!(
+            "J1_{}_{}_{}.csv",
+            pretty_sci(args.n),
+            pretty_sci(args.n / 1_000_000),
+            args.nas,
+        );
+        let mut pb = tqdm!(total = args.n as usize / 1_000_000, position = 3);
+        pb.set_postfix(format!("{}", output_name));
+        let _ = pb.refresh();
+        generate_csv(
+            &mut JoinGeneratorSmall::new(args.n, args.k, args.nas, args.seed),
+            &output_name,
+            &mut pb,
+            args.n / 1_000_000,
+        );
+    });
+
+    let _joinmedium_gen = thread::spawn(move || {
+        let output_name = format!(
+            "J1_{}_{}_{}.csv",
+            pretty_sci(args.n),
+            pretty_sci(args.n / 1_000),
+            args.nas,
+        );
+        let mut pb = tqdm!(total = args.n as usize / 1_000, position = 4);
+        pb.set_postfix(format!("{}", output_name));
+        let _ = pb.refresh();
+        generate_csv(
+            &mut JoinGeneratorMedium::new(args.n, args.k, args.nas, args.seed),
+            &output_name,
+            &mut pb,
+            args.n / 1_000,
+        );
+    });
+
     _groupby_gen.join().unwrap();
     _joinbig_gen.join().unwrap();
+    _joinbig_na_gen.join().unwrap();
+    _joinsmall_gen.join().unwrap();
+    _joinmedium_gen.join().unwrap();
+
+    println!("{}", "Done.")
 }

--- a/h2o-data-rust/src/main.rs
+++ b/h2o-data-rust/src/main.rs
@@ -1,11 +1,14 @@
-use std::io::prelude::*;
+mod generators;
+
+use std::io::{prelude::*, BufWriter};
+use std::thread;
 use std::{fs, path::PathBuf};
 
 use clap::Parser;
-use kdam::tqdm;
-use rand::distributions::{Distribution, Uniform};
-use rand::prelude::*;
-use rand_chacha::ChaCha8Rng;
+use generators::JoinGeneratorBig;
+use kdam::{tqdm, Bar, BarExt};
+
+use crate::generators::{GroupByGenerator, RowGenerator};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -13,84 +16,18 @@ struct CliArgs {
     /// Number of rows
     #[arg(long)]
     n: u64,
+
     /// Number of keys
     #[arg(long)]
     k: u64,
+
     /// Number of NAs
     #[arg(long, default_value_t = 0)]
     nas: u8,
+
     /// Random seed
     #[arg(long, default_value_t = 108)]
     seed: u64,
-}
-
-struct RowGenerator {
-    nas: u8,
-    distr_k: Uniform<u64>,
-    distr_nk: Uniform<u64>,
-    distr_5: Uniform<u8>,
-    distr_15: Uniform<u8>,
-    distr_float: Uniform<f64>,
-    distr_nas: Uniform<u8>,
-    rng: ChaCha8Rng,
-}
-
-impl RowGenerator {
-    fn new(n: u64, k: u64, nas: u8, seed: u64) -> Self {
-        RowGenerator {
-            nas,
-            distr_k: Uniform::<u64>::try_from(1..=k).unwrap(),
-            distr_nk: Uniform::<u64>::try_from(1..=(n / k)).unwrap(),
-            distr_5: Uniform::<u8>::try_from(1..=5).unwrap(),
-            distr_15: Uniform::<u8>::try_from(1..=15).unwrap(),
-            distr_float: Uniform::<f64>::try_from(0.0..=100.0).unwrap(),
-            distr_nas: Uniform::<u8>::try_from(0..=100).unwrap(),
-            rng: ChaCha8Rng::seed_from_u64(seed),
-        }
-    }
-
-    fn get_csv_header(&self) -> String {
-        "id1,id2,id3,id4,id5,id6,v1,v2,v3\n".to_string()
-    }
-
-    fn get_csv_row(&mut self) -> String {
-        format!(
-            "{},{},{},{},{},{},{},{},{}",
-            if self.distr_nas.sample(&mut self.rng) >= self.nas {
-                format!("id{:03}", self.distr_k.sample(&mut self.rng))
-            } else {
-                "".to_string()
-            },
-            if self.distr_nas.sample(&mut self.rng) >= self.nas {
-                format!("id{:03}", self.distr_k.sample(&mut self.rng))
-            } else {
-                "".to_string()
-            },
-            if self.distr_nas.sample(&mut self.rng) >= self.nas {
-                format!("id{:010}", self.distr_nk.sample(&mut self.rng))
-            } else {
-                "".to_string()
-            },
-            if self.distr_nas.sample(&mut self.rng) >= self.nas {
-                format!("{}", self.distr_k.sample(&mut self.rng))
-            } else {
-                "".to_string()
-            },
-            if self.distr_nas.sample(&mut self.rng) >= self.nas {
-                format!("{}", self.distr_k.sample(&mut self.rng))
-            } else {
-                "".to_string()
-            },
-            if self.distr_nas.sample(&mut self.rng) >= self.nas {
-                format!("{}", self.distr_nk.sample(&mut self.rng))
-            } else {
-                "".to_string()
-            },
-            self.distr_5.sample(&mut self.rng),
-            self.distr_15.sample(&mut self.rng),
-            self.distr_float.sample(&mut self.rng),
-        )
-    }
 }
 
 fn pretty_sci(num: u64) -> String {
@@ -100,33 +37,71 @@ fn pretty_sci(num: u64) -> String {
         digits.push((x % 10) as u8);
         x = x / 10;
     }
-    format!("{}e{}", digits.pop().unwrap(), digits.len())
+    format!("{}e{}", digits.pop().unwrap_or(0), digits.len())
+}
+
+fn generate_csv(
+    generator: &mut dyn RowGenerator,
+    file_name: &str,
+    pb: &mut Bar,
+    n_rows: u64,
+) -> () {
+    let _ = fs::write(PathBuf::from(&file_name), generator.get_csv_header());
+    let file = fs::OpenOptions::new()
+        .append(true)
+        .write(true)
+        .open(file_name)
+        .unwrap();
+
+    let mut writer = BufWriter::new(file);
+    for _ in 0..n_rows {
+        writer
+            .write(generator.get_csv_row().as_bytes())
+            .expect("couldn't write to file");
+        pb.update(1).unwrap();
+    }
 }
 
 fn main() {
     let args = CliArgs::parse();
 
-    let output_file_name = format!(
-        "G1_{}_{}_{}.csv",
-        pretty_sci(args.n),
-        pretty_sci(args.k),
-        args.nas
-    );
-    println!("Write output to {}", output_file_name);
-    let mut row_generator = RowGenerator::new(args.n, args.k, args.nas, args.seed);
-    let _ = fs::write(
-        PathBuf::from(&output_file_name),
-        row_generator.get_csv_header(),
-    );
-    let mut file = fs::OpenOptions::new()
-        .append(true)
-        .write(true)
-        .open(output_file_name)
-        .unwrap();
+    let _groupby_gen = thread::spawn(move || {
+        let output_name = format!(
+            "G1_{}_{}_{}_{}.csv",
+            pretty_sci(args.n),
+            pretty_sci(args.n),
+            args.k,
+            args.nas
+        );
+        let mut pb = tqdm!(total = args.n as usize, position = 0);
+        pb.set_postfix(format!("{}", output_name));
+        let _ = pb.refresh();
+        generate_csv(
+            &mut GroupByGenerator::new(args.n, args.k, args.nas, args.seed),
+            &output_name,
+            &mut pb,
+            args.n,
+        );
+    });
 
-    for _ in tqdm!(0..args.n) {
-        if let Err(e) = writeln!(file, "{}", row_generator.get_csv_row()) {
-            eprintln!("couldn't write to file: {}", e);
-        }
-    }
+    let _joinbig_gen = thread::spawn(move || {
+        let output_name = format!(
+            "J1_{}_{}_{}.csv",
+            pretty_sci(args.n),
+            pretty_sci(args.n),
+            pretty_sci(args.nas.into()),
+        );
+        let mut pb = tqdm!(total = args.n as usize, position = 1);
+        pb.set_postfix(format!("{}", output_name));
+        let _ = pb.refresh();
+        generate_csv(
+            &mut JoinGeneratorBig::new(args.n, args.k, args.nas, args.seed),
+            &output_name,
+            &mut pb,
+            args.n,
+        );
+    });
+
+    _groupby_gen.join().unwrap();
+    _joinbig_gen.join().unwrap();
 }


### PR DESCRIPTION
+ README
+ parallel data generation


Main refactoring is about moving generation logic into a separate file `generators.rs` where the core abstraction `RowGenerator` is placed.

For this trait there are four implementations:
1. GroupBy generator (mostly old code, just refactored)
2. Join generator LHS
3. Join generator RHS medium
4. Join generator RHS small


Also cli args description was improved a little.